### PR TITLE
Execution count

### DIFF
--- a/Pod/Classes/CCNMigrationQueue.h
+++ b/Pod/Classes/CCNMigrationQueue.h
@@ -15,7 +15,14 @@
 
 + (instancetype)sharedQueue;
 
-- (void)execute:(CIRDatabase*)database;
+- (BOOL)checkForExecutions:(CIRDatabase *)database;
+
+- (NSUInteger)executionsCountForDatabase:(CIRDatabase *)database;
+
+- (void)execute:(CIRDatabase *)database;
+
+- (void)execute:(CIRDatabase *)database progress:(void (^)(CCNAbstractMigration *, int, int))progress;
+
 - (void)registerMigrationClass:(Class)migrationClass withVersion:(long long)version;
 
 @end


### PR DESCRIPTION
This pull-request adds a way to count migration executions, and, with that information, provides a simple API to access the execution progress.
